### PR TITLE
Caching Images on Home, Manual Refresh, and Post Rework

### DIFF
--- a/remi-app/app/(auth)/(tabs)/home.tsx
+++ b/remi-app/app/(auth)/(tabs)/home.tsx
@@ -44,7 +44,6 @@ import {
   arrayUnion,
   deleteDoc,
   arrayRemove,
-  orderBy,
   Timestamp,
 } from "firebase/firestore";
 import { db, auth } from "../../../firebaseConfig"; // Ensure correct imports

--- a/remi-app/app/(auth)/(tabs)/home.tsx
+++ b/remi-app/app/(auth)/(tabs)/home.tsx
@@ -918,7 +918,6 @@ const Home: React.FC = () => {
   const scrollViewRef = useRef<ScrollView>(null);
   const setResetScroll = useContext(ScrollResetContext);
   const [refreshing, setRefreshing] = useState(false);
-  const lastCreatedAtRef = useRef(null);
   const [loading, setLoading] = useState(false);
   const [friendsListChange, setFriendsListChange] = useState(false);
   const POSTS_PER_PAGE = 20;
@@ -933,7 +932,11 @@ const Home: React.FC = () => {
 
   const fetchPostsWithCommentsFlag = async () => {
     console.log(friendsList.current);
-    if (friendsList.current.length === 0 || loading) return;
+    if (loading) return;
+    if (friendsList.current.length == 0) {
+      postsArrRef.current = [];
+      return;
+    }
 
     setLoading(true);
     const postsRef = collection(db, "Posts");
@@ -943,10 +946,6 @@ const Home: React.FC = () => {
       orderBy("createdAt", "asc"),
       limit(POSTS_PER_PAGE)
     );
-
-    if (lastCreatedAtRef.current) {
-      postsQuery = query(postsQuery, startAfter(lastCreatedAtRef.current));
-    }
 
     try {
       const querySnapshot = await getDocs(postsQuery);
@@ -976,14 +975,7 @@ const Home: React.FC = () => {
         })
       );
 
-      postsArrRef.current = [...newPosts.reverse(), ...postsArrRef.current];
-      if (!querySnapshot.empty) {
-        // Set lastVisible to the last document in the current query snapshot
-        const lastDoc = querySnapshot.docs[querySnapshot.docs.length - 1];
-        lastCreatedAtRef.current = lastDoc.data().createdAt;
-      } else {
-        console.log("NO NEW POSTS");
-      }
+      postsArrRef.current = newPosts.reverse();
     } catch (error) {
       console.error("Error fetching posts:", error);
     } finally {

--- a/remi-app/app/(auth)/(tabs)/home.tsx
+++ b/remi-app/app/(auth)/(tabs)/home.tsx
@@ -19,6 +19,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons"; // For icons
+import { Image as ExpoImage } from "expo-image";
 import {
   collection,
   addDoc,
@@ -26,8 +27,12 @@ import {
   getDocs,
   doc,
   query,
+  QueryDocumentSnapshot,
   QuerySnapshot,
   DocumentData,
+  orderBy,
+  limit,
+  startAfter,
   where,
   onSnapshot,
   updateDoc,
@@ -97,6 +102,8 @@ const hashtagMap: { [key: string]: string } = {
   "29": "Beverages",
   "30": "Japanese",
 };
+
+const blurhash = "L6PZfSi_.AyE_3t7t7R**0o#DgR4";
 
 interface RecipePostProps {
   postID: string;
@@ -496,9 +503,11 @@ export const RecipePost: React.FC<RecipePostProps> = ({
     <View style={Ustyles.post}>
       <View style={Ustyles.postHeader}>
         <View style={Ustyles.userInfo}>
-          <Image
+          <ExpoImage
             source={require("../../../assets/placeholders/user-avatar.png")}
             style={Ustyles.avatar}
+            placeholder={blurhash}
+            transition={200}
           />
           <View>
             <Text style={Ustyles.username}>{username}</Text>
@@ -603,13 +612,15 @@ export const RecipePost: React.FC<RecipePostProps> = ({
                   <ActivityIndicator size="large" color="#0D5F13" />
                 </View>
               )}
-              <Image
+              <ExpoImage
                 source={
                   mediaUrl
                     ? { uri: mediaUrl }
                     : require("../../../assets/placeholders/recipe-image.png")
                 }
                 style={Ustyles.recipeImage}
+                placeholder={blurhash}
+                transition={200}
                 onLoad={() => handleImageLoad(postID)} // Updates loading state to false
                 onError={() => handleImageError(postID)} // Handles errors
               />
@@ -699,10 +710,12 @@ export const RecipePost: React.FC<RecipePostProps> = ({
             >
               <Ionicons name="close" size={30} color="#FFF" />
             </TouchableOpacity>
-            <Image
+            <ExpoImage
               source={{ uri: mediaUrl }}
               style={styles.fullScreenImage}
-              resizeMode="contain"
+              placeholder={blurhash}
+              transition={200}
+              contentFit="contain"
             />
           </View>
         </Modal>
@@ -715,7 +728,7 @@ export const RecipePost: React.FC<RecipePostProps> = ({
 const Home: React.FC = () => {
   const insets = useSafeAreaInsets();
   const user = auth.currentUser;
-  const [posts, setPosts] = useState<DocumentData[]>([]);
+  const postsArrRef = useRef<DocumentData[]>([]);
   //record notification count using state
   // const [pendingRequestsCount, setPendingRequestsCount] = useState(0);
   const [friendRequests, setFriendRequests] = useState<
@@ -726,48 +739,76 @@ const Home: React.FC = () => {
   const scrollViewRef = useRef<ScrollView>(null);
   const setResetScroll = useContext(ScrollResetContext);
   const [refreshing, setRefreshing] = useState(false);
+  const lastVisibleRef = useRef<QueryDocumentSnapshot | null>(null);
+  const [loading, setLoading] = useState(false);
+  const POSTS_PER_PAGE = 20;
 
-  const onRefresh = React.useCallback(() => {
+  const onRefresh = React.useCallback(async () => {
     setRefreshing(true);
     console.log("Trying to refresh");
-    fetchPostsWithCommentsFlag().then(() => setRefreshing(false));
-
+    await fetchFriendsList();
+    await fetchPostsWithCommentsFlag();
+    setRefreshing(false);
     console.log("Done w refresh");
-  }, [friendsList]);
+  }, []);
 
   const fetchPostsWithCommentsFlag = async () => {
-    console.log("This is the friends list at fetch post: ", friendsList);
+    if (friendsList.length === 0 || loading) return;
+
+    setLoading(true);
     const postsRef = collection(db, "Posts");
-    const postsQuery = query(postsRef, where("userId", "in", friendsList));
-
-    const querySnapshot = await getDocs(postsQuery);
-    const currentUserId = auth.currentUser?.uid;
-
-    const postsWithCommentsFlag = await Promise.all(
-      querySnapshot.docs.map(async (doc) => {
-        const postData = doc.data();
-        const postId = doc.id;
-
-        // Check if the current user has commented on this post
-        const commentsRef = collection(db, "Comments");
-        const commentsQuery = query(
-          commentsRef,
-          where("postId", "==", postId),
-          where("userId", "==", currentUserId)
-        );
-
-        const userHasCommentedSnapshot = await getDocs(commentsQuery);
-        const userHasCommented = !userHasCommentedSnapshot.empty;
-
-        return {
-          ...postData,
-          postID: postId,
-          userHasCommented,
-        };
-      })
+    let postsQuery = query(
+      postsRef,
+      where("userId", "in", friendsList),
+      orderBy("createdAt", "asc"),
+      limit(POSTS_PER_PAGE)
     );
-    console.log("Refreshing from hometsx..");
-    setPosts(postsWithCommentsFlag);
+
+    if (lastVisibleRef.current) {
+      postsQuery = query(postsQuery, startAfter(lastVisibleRef.current));
+    }
+
+    try {
+      const querySnapshot = await getDocs(postsQuery);
+      const currentUserId = auth.currentUser?.uid;
+
+      const newPosts = await Promise.all(
+        querySnapshot.docs.map(async (doc) => {
+          const postData = doc.data();
+          const postId = doc.id;
+
+          // Check if the current user has commented on this post
+          const commentsRef = collection(db, "Comments");
+          const commentsQuery = query(
+            commentsRef,
+            where("postId", "==", postId),
+            where("userId", "==", currentUserId)
+          );
+
+          const userHasCommentedSnapshot = await getDocs(commentsQuery);
+          const userHasCommented = !userHasCommentedSnapshot.empty;
+
+          return {
+            ...postData,
+            postID: postId,
+            userHasCommented,
+          };
+        })
+      );
+
+      postsArrRef.current = [...newPosts.reverse(), ...postsArrRef.current];
+      if (!querySnapshot.empty) {
+        // Set lastVisible to the last document in the current query snapshot
+        const lastDoc = querySnapshot.docs[querySnapshot.docs.length - 1];
+        lastVisibleRef.current = lastDoc;
+      } else {
+        console.log("NO NEW POSTS");
+      }
+    } catch (error) {
+      console.error("Error fetching posts:", error);
+    } finally {
+      setLoading(false);
+    }
   };
 
   useEffect(() => {
@@ -779,17 +820,6 @@ const Home: React.FC = () => {
       setResetScroll(() => resetScroll);
     }
   }, [setResetScroll]);
-
-  useEffect(() => {
-    console.log("Updated friendsList:", friendsList);
-  }, [friendsList]);
-
-  // Fetch all posts from Firestore
-  useEffect(() => {
-    if (friendsList.length === 0) return;
-
-    fetchPostsWithCommentsFlag();
-  }, [friendsList]);
 
   // Use `useEffect` to fetch posts when the component mounts and every minute
   useEffect(() => {
@@ -819,32 +849,32 @@ const Home: React.FC = () => {
     }
   }, [user]);
 
-  useEffect(() => {
-    const fetchFriendsList = async () => {
-      if (!user) return;
+  const fetchFriendsList = async () => {
+    if (!user) return;
 
-      try {
-        const userDoc = await getDoc(doc(db, "RemiUsers", user.uid));
-        if (userDoc.exists()) {
-          const userData = userDoc.data();
-          const friendsEmails = userData.friends_list || [];
+    try {
+      const userDoc = await getDoc(doc(db, "RemiUsers", user.uid));
+      if (userDoc.exists()) {
+        const userData = userDoc.data();
+        const friendsEmails = userData.friends_list || [];
 
-          if (friendsEmails.length > 0) {
-            const q = query(
-              collection(db, "RemiUsers"),
-              where("email", "in", friendsEmails)
-            );
-            const friendsSnapshot = await getDocs(q);
-            const friendsIds = friendsSnapshot.docs.map((doc) => doc.id);
-            setFriendsList(friendsIds);
-            console.log("Updated friendsList:", friendsIds);
-          }
+        if (friendsEmails.length > 0) {
+          const q = query(
+            collection(db, "RemiUsers"),
+            where("email", "in", friendsEmails)
+          );
+          const friendsSnapshot = await getDocs(q);
+          const friendsIds = friendsSnapshot.docs.map((doc) => doc.id);
+          setFriendsList(friendsIds);
+          console.log("Updated friendsList:", friendsIds);
         }
-      } catch (error) {
-        console.error("Error fetching friend list:", error);
       }
-    };
+    } catch (error) {
+      console.error("Error fetching friend list:", error);
+    }
+  };
 
+  useEffect(() => {
     fetchFriendsList();
   }, [user]); // Only run when `user` changes
 
@@ -887,37 +917,31 @@ const Home: React.FC = () => {
               </TouchableOpacity>
             </View>
           </View>
-          {posts
-            .sort((a, b) => {
-              const dateA = a.createdAt ? new Date(a.createdAt) : new Date(0);
-              const dateB = b.createdAt ? new Date(b.createdAt) : new Date(0);
-              return dateB.getTime() - dateA.getTime();
-            })
-            .map((post, index) => (
-              <View key={post.postID}>
-                <RecipePost
-                  key={index}
-                  userID={post.userId || "Anonymous"}
-                  timeAgo={
-                    post.createdAt
-                      ? new Date(post.createdAt)
-                      : new Date(2002, 2, 8)
-                  }
-                  likes={post.likesCount || 0}
-                  comments={post.comments || 0}
-                  recipeName={post.title || "Untitled Recipe"}
-                  price={post.Price || 0.0}
-                  difficulty={post.Difficulty || 0}
-                  time={post.Time || 0}
-                  caption={post.caption || "No caption"}
-                  hashtags={post.hashtags || ["None"]}
-                  mediaUrl={post.mediaUrl || ""}
-                  postID={post.postID}
-                  userHasCommented={post.userHasCommented}
-                />
-                <View style={Ustyles.separator} />
-              </View>
-            ))}
+          {postsArrRef.current.map((post, index) => (
+            <View key={post.postID}>
+              <RecipePost
+                key={index}
+                userID={post.userId || "Anonymous"}
+                timeAgo={
+                  post.createdAt
+                    ? new Date(post.createdAt)
+                    : new Date(2002, 2, 8)
+                }
+                likes={post.likesCount || 0}
+                comments={post.comments || 0}
+                recipeName={post.title || "Untitled Recipe"}
+                price={post.Price || 0.0}
+                difficulty={post.Difficulty || 0}
+                time={post.Time || 0}
+                caption={post.caption || "No caption"}
+                hashtags={post.hashtags || ["None"]}
+                mediaUrl={post.mediaUrl || ""}
+                postID={post.postID}
+                userHasCommented={post.userHasCommented}
+              />
+              <View style={Ustyles.separator} />
+            </View>
+          ))}
         </ScrollView>
         {/* <Button title="Sign out" onPress={() => signOut(auth)} color="#0D5F13" /> */}
       </View>


### PR DESCRIPTION
This change will allow users to manually reload the home page. In addition it introduces image caching and optimizations through the use of Expo Image. Lastly, posts are now a reference and not a state allowing it to carry thru re-renders.